### PR TITLE
Datatype to filter set

### DIFF
--- a/src/FLComponents/Filters.tsx
+++ b/src/FLComponents/Filters.tsx
@@ -19,8 +19,8 @@ import FiltersLoader from "./Loader/FiltersLoader.tsx";
 
 export default function Filters() {
     // global vars
-    const {distinctCountries, distinctOwners, selCountries, setSelCountries, selOwners,
-        setSelOwners} = useInitializer();
+    const {distinctCountries, distinctOwners, distinctDatatypes, selCountries, setSelCountries, selOwners, selDatatypes,
+        setSelDatatypes, setSelOwners} = useInitializer();
     const [isFetched, setIsFetched] = useState<boolean>(false);
     // toggles selected element
     const handleCheckbox = (value: string,
@@ -93,6 +93,32 @@ export default function Filters() {
                                             control={<Checkbox
                                                 onChange={() => handleCheckbox(i, setSelOwners)}
                                                 checked={selOwners.has(i)}/>} label={i}
+                                        />
+                                        <Divider sx={{mt: 1, mb: 1}} orientation="horizontal"/>
+                                    </>
+                                ))}
+                            </Box>
+                        </AccordionDetails>
+                    </Accordion>
+                    <Accordion defaultExpanded sx={{m:1}}>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
+                            Datatypes ({selDatatypes.size} Selected)
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <Box sx={{display: "flex", flexDirection:"column"}}>
+                                <Button
+                                    variant="outlined"
+                                    onClick={() => handleReset(setSelDatatypes)}
+                                    disabled={selDatatypes.size === 0}
+                                >Clear selection
+                                </Button>
+                                <Divider sx={{mt: 1, mb: 1}} orientation="horizontal"/>
+                                {distinctDatatypes.size > 0 && [...distinctDatatypes.values()].map((i) => (
+                                    <>
+                                        <FormControlLabel
+                                            control={<Checkbox
+                                                onChange={() => handleCheckbox(i, setSelDatatypes)}
+                                                checked={selDatatypes.has(i)}/>} label={i}
                                         />
                                         <Divider sx={{mt: 1, mb: 1}} orientation="horizontal"/>
                                     </>

--- a/src/FLComponents/Loader/MapLayerLoader.tsx
+++ b/src/FLComponents/Loader/MapLayerLoader.tsx
@@ -18,8 +18,6 @@ export default function MapLayerLoader({setIsFetched}:{setIsFetched:React.Dispat
             return;
         }
         const data:IMapMarkers[] = await res.json();
-        // convert str arr to set
-        data.forEach(i => {i.datatypes = new Set<string>(i.datatypes)})
         // update map marker global var
         setMapMarkers(data);
     }, [setMapMarkers]);

--- a/src/FLComponents/Loader/MapLayerLoader.tsx
+++ b/src/FLComponents/Loader/MapLayerLoader.tsx
@@ -18,6 +18,9 @@ export default function MapLayerLoader({setIsFetched}:{setIsFetched:React.Dispat
             return;
         }
         const data:IMapMarkers[] = await res.json();
+        // convert str arr to set
+        data.forEach(i => {i.datatypes = new Set<string>(i.datatypes)})
+        // update map marker global var
         setMapMarkers(data);
     }, [setMapMarkers]);
     // execute fetchData

--- a/src/Providers/ProviderInitializer.tsx
+++ b/src/Providers/ProviderInitializer.tsx
@@ -7,12 +7,15 @@ interface IInitializerContext {
     mapMarkers : IMapMarkers[];
     setMapMarkers: React.Dispatch<React.SetStateAction<IMapMarkers[]>>
     filteredMarkers: IMapMarkers[];
+    distinctDatatypes: Set<string>;
     distinctOwners : Set<string>;
     setDistinctOwners: React.Dispatch<React.SetStateAction<Set<string>>>
     distinctCountries: Set<string>;
     setDistinctCountries: React.Dispatch<React.SetStateAction<Set<string>>>;
     selCountries: Set<string>;
     setSelCountries: React.Dispatch<React.SetStateAction<Set<string>>>
+    selDatatypes: Set<string>;
+    setSelDatatypes: React.Dispatch<React.SetStateAction<Set<string>>>
     selOwners: Set<string>;
     setSelOwners: React.Dispatch<React.SetStateAction<Set<string>>>
 }
@@ -22,9 +25,13 @@ const InitializerContext = createContext<IInitializerContext | null>(null);
 export default function ProviderInitializer({children}:{children: React.ReactNode}) {
     // holds all existing station from db
     const [mapMarkers, setMapMarkers] = useState<IMapMarkers[]>([]);
-    // holds all selected/filtered countries and owners
+    // holds all selected/filtered countries, owners, and datatypes
     const [selCountries, setSelCountries] = useState<Set<string>>(new Set<string>(["US"]));
     const [selOwners, setSelOwners] = useState<Set<string>>(new Set<string>());
+    const [selDatatypes, setSelDatatypes] = useState<Set<string>>(new Set<string>());
+    // holds all unique datatypes
+    const distinctDatatypes = new Set(["adcp", "cwind", "dart", "drift", "drift", "ocean", "rain", "spec",
+        "spectral", "srad", "supl", "txt"]);
     // holds all unique (non-dup) owners
     const [distinctOwners, setDistinctOwners] = useState<Set<string>>(new Set<string>());
     // holds all unique (non-dup) countries
@@ -43,12 +50,24 @@ export default function ProviderInitializer({children}:{children: React.ReactNod
         // filter stations based on selected owners
         if(selOwners.size > 0)
             temp = temp.filter(i => selOwners.has(i.owner_name))
+        // filter stations based on selected datatypes
+        if(selDatatypes.size > 0)
+            temp = temp.filter(i => {
+                // convert str arr to set
+                const s = new Set<string>(i.datatypes);
+                // determine if selDatatypes is subset of station's datatype
+                for(const i of selDatatypes) {
+                    if(!s.has(i)) return false;
+                }
+                return true;
+            })
         return temp;
-    }, [selCountries, selOwners, mapMarkers]);
+    }, [mapMarkers, selCountries, selOwners, selDatatypes]);
 
     return (
-        <InitializerContext value={{mapMarkers, setMapMarkers, filteredMarkers, distinctCountries, setDistinctCountries,
-            distinctOwners, setDistinctOwners, selCountries, setSelCountries, selOwners, setSelOwners}}>
+        <InitializerContext value={{mapMarkers, setMapMarkers, filteredMarkers, distinctDatatypes, distinctCountries,
+            setDistinctCountries, distinctOwners, setDistinctOwners, selCountries, setSelCountries, selOwners,
+            setSelOwners, selDatatypes, setSelDatatypes}}>
             {children}
         </InitializerContext>
     )

--- a/src/Providers/ProviderInitializer.tsx
+++ b/src/Providers/ProviderInitializer.tsx
@@ -42,7 +42,7 @@ export default function ProviderInitializer({children}:{children: React.ReactNod
         // get all stations
         let temp = [...mapMarkers];
         // if no filters are set, return all map markers
-        if(selCountries.size === 0 && selOwners.size === 0)
+        if(selCountries.size === 0 && selOwners.size === 0 && selDatatypes.size == 0)
             return [];
         // filter stations based on selected countries
         if(selCountries.size > 0)
@@ -57,6 +57,7 @@ export default function ProviderInitializer({children}:{children: React.ReactNod
                 const s = new Set<string>(i.datatypes);
                 // determine if selDatatypes is subset of station's datatype
                 for(const i of selDatatypes) {
+                    console.log(s);
                     if(!s.has(i)) return false;
                 }
                 return true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
 		}
 	],
 	"compilerOptions": {
+		"target": "ES2015",
+		"lib": ["ES2015", "DOM"],
 		"types": [
 			"./worker-configuration.d.ts"
 		]

--- a/types/IMapMarkers.ts
+++ b/types/IMapMarkers.ts
@@ -4,5 +4,5 @@ export interface IMapMarkers {
     code: string;
     owner_name: string;
     country_code: string;
-    datatypes: string[] | Set<string>;
+    datatypes: string[];
 }

--- a/types/IMapMarkers.ts
+++ b/types/IMapMarkers.ts
@@ -4,4 +4,5 @@ export interface IMapMarkers {
     code: string;
     owner_name: string;
     country_code: string;
+    datatypes: string[] | Set<string>;
 }

--- a/types/IMapMarkersFlat.ts
+++ b/types/IMapMarkersFlat.ts
@@ -1,0 +1,18 @@
+export interface IMapMarkersFlat {
+    station_id: string;
+    location: string | number[];
+    code: string;
+    owner_name: string;
+    country_code: string;
+    adcp: number;
+    cwind: number;
+    dart: number;
+    drift: number;
+    ocean: number;
+    rain: number;
+    spec: number;
+    spectral: number;
+    srad: number;
+    supl: number;
+    txt: number;
+}

--- a/worker/retriever.ts
+++ b/worker/retriever.ts
@@ -1,5 +1,6 @@
 // types and interfaces
 import type {IMeteorologicalData} from "../types/IMeteorologicalData";
+import type {IMapMarkersFlat} from "../types/IMapMarkersFlat";
 import type {IMapMarkers} from "../types/IMapMarkers";
 import type {IMetadata} from "../types/IMetadata";
 import type {IDataSet} from "../types/IDataSet";
@@ -8,14 +9,16 @@ export function retriever(db:D1Database) {
     // get map markers
     async function retrieveMapMarkers():Promise<IMapMarkers[]> {
         const {results} = await db.prepare(
-            "SELECT s.station_id, s.location, so.code, so.name AS owner_name, so.country_code " +
-            "FROM stations AS s JOIN stations_owner AS so " +
-            "ON s.owner = so.code"
-        ).all<IMapMarkers>();
+            "SELECT s.station_id, s.location, so.code, so.name AS owner_name, so.country_code, " +
+            "sd.adcp, sd.cwind, sd.dart, sd.drift, sd.ocean, sd.rain, sd.spec, sd.spectral, " +
+            "sd.srad, sd.supl, sd.txt " +
+            "FROM stations AS s JOIN stations_owner AS so JOIN stations_datatype as sd " +
+            "ON s.owner = so.code AND s.station_id = sd.station_id"
+        ).all<IMapMarkersFlat>();
         results.forEach(s => {
             s.location = normalizeLocation(s.location as string);
         })
-        return results;
+        return convertFlatType(results);
     }
 
     // retrieves metadata for specified station id
@@ -115,6 +118,34 @@ async function fetchData(input:string) {
         return text.split("\n");
     } else
         return [];
+}
+
+function convertFlatType(data:IMapMarkersFlat[]) {
+    const temp:IMapMarkers[] = [];
+    const datatypes: Set<string> = new Set(["adcp", "cwind", "dart", "drift", "drift", "ocean", "rain", "spec",
+        "spectral", "srad", "supl", "txt"]);
+    if(data.length < 1) return temp;
+    data.forEach(i => {
+        //
+        const s:string[] = [];
+        //
+        Object.entries(i).forEach(([key, value]:[string, number]) => {
+            if(datatypes.has(key) && value === 1)
+                s.push(key);
+        })
+        //
+        const tuple:IMapMarkers = {
+            station_id: i.station_id,
+            location: i.location,
+            code: i.code,
+            owner_name: i.owner_name,
+            country_code: i.country_code,
+            datatypes: s,
+        }
+        temp.push(tuple);
+    })
+    return temp;
+
 }
 
 // convert location to lat/lon


### PR DESCRIPTION
What's new changed:

- Modified MapMarkers.ts to retrieve datatypes per station.
  - Now consists of MapMarkersFlat and MapMarkers (2 types) since retrieving data from D1Database requires a flat type/interfaces 
  - MapMarkersFlat includes all datatype attributes
  - MapMarkers now includes datatype: string[], which represents the available datatype per station.
- Added datatypes tab in Filter component
  - Filter station based on datatype availability. 